### PR TITLE
Change boolean parameter 'auto_ack' to string parameter 'ack_mode'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,9 +197,11 @@ transport
     set to "websockets" to send MQTT over WebSockets. Leave at the default of
     "tcp" to use raw TCP.
 
-auto_ack
-    set to False to let application acknowledge messages using the ack(message.mid)
-    entry point, instead of letting the library take care of it on receipt.
+ack_mode
+    set to "app_ack_in_order" to let application acknowledge messages using the ``ack(message.mid)`
+    entry point. Note that the mqtt specification requires that messages be acknowledged
+    in the same order as they are received.
+    Leave at the default of "auto" to letting the library take care of it on receipt.
 
 Constructor Example
 ...................


### PR DESCRIPTION
According to the suggestion of @BBBSnowball the parameter for the control of the acknowledgement behavior is now a string. Only the values "auto" and "app_ack_in_order" are currently allowed.
Also i have added the note with the acknowledgement order in the docstring and readme. 

Hope the changes help to get the feature upstream. 